### PR TITLE
Use Serialization package for extserialize/deserialize

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,4 +6,5 @@ version = "0.2.0"
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/MsgPack.jl
+++ b/src/MsgPack.jl
@@ -1,5 +1,6 @@
 module MsgPack
 
+import Serialization: serialize, deserialize
 import Compat: take!, xor
 
 export pack, unpack, Ext

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,3 +116,14 @@ b = rand(UInt8, 2^14)
 b = rand(UInt8, 2^19)
 @test ck_pack(Ext(-123, b, impltype=true),
               vcat(0xc9, 0x00, 0x08, 0x00, 0x00, 0x85, b))
+
+# extserialize
+struct Point
+    x :: Int64
+    y :: Int64
+end
+
+b = Point(1, 2)
+ser = MsgPack.extserialize(101, b)
+deser = MsgPack.extdeserialize(ser)
+@test deser == (101, b)


### PR DESCRIPTION
`extserialize`/`extdeserialize` didn't work under Julia 1.0 because the `serialize`/`deserialize` functions moved to the `Serialization` package.