### PR TITLE
do not attempt to read stream to end by default

### DIFF
--- a/src/MsgPack.jl
+++ b/src/MsgPack.jl
@@ -81,10 +81,9 @@ function readu64(s, t)
     end
 end
 
-unpack(s) = unpack_buffer(IOBuffer(s))
-
-# Read the whole buffer in one go is more performant
-unpack(io::IO) = unpack_buffer(IOBuffer(read(io)))
+unpack(s) = unpack(IOBuffer(s))
+unpack(bytes::Vector) = unpack(IOBuffer(bytes))
+unpack(io::IO) = unpack_buffer(io)
 
 function unpack_buffer(s::IO)
     b = read(s, UInt8)


### PR DESCRIPTION
This PR is made against #27. After reviewing there, it seems perhaps a bit aggressive to do a read-to-end by default; it could result in unexpected behavior for non-file-backed IO streams.

This change gives callers a bit more control while still making it convenient to pass byte vectors to `unpack` (e.g. by calling `unpack(read(io))`) .