### PR TITLE
change API to specify field assumptions at unpack callsite instead of globally

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,6 +19,7 @@ pack
 MsgPack.msgpack_type
 MsgPack.to_msgpack
 MsgPack.from_msgpack
+MsgPack.construct
 ```
 
 ## Julia <--> MessagePack Interface Types
@@ -35,8 +36,7 @@ ArrayType
 MapType
 ExtensionType
 AnyType
-ImmutableStructType
-MutableStructType
+StructType
 ```
 
 ## View Types

--- a/src/pack.jl
+++ b/src/pack.jl
@@ -46,11 +46,11 @@ function pack_type(io, t::AnyType, x)
 end
 
 #####
-##### `ImmutableStructType` + `MutableStructType`
+##### `StructType`
 #####
 
 function pack_type(io,
-                   t::Union{ImmutableStructType,MutableStructType},
+                   t::StructType,
                    x::T) where {T}
     N = fieldcount(T)
     if N <= 15

--- a/src/pack.jl
+++ b/src/pack.jl
@@ -49,9 +49,7 @@ end
 ##### `StructType`
 #####
 
-function pack_type(io,
-                   t::StructType,
-                   x::T) where {T}
+function pack_type(io, t::StructType, x::T) where {T}
     N = fieldcount(T)
     if N <= 15
         write(io, magic_byte_min(MapFixFormat) | UInt8(N))

--- a/src/types.jl
+++ b/src/types.jl
@@ -433,16 +433,6 @@ See also: [`Extension`](@ref), [`extserialize`](@ref)
 extdeserialize(x::Extension) = (x.type, deserialize(IOBuffer(x.data)))
 
 #####
-##### `Strict`
-#####
-
-struct Strict{T} end
-
-msgpack_type(::Type{Strict{T}}) where {T} = StructType()
-
-unwrap_exact(::Type{Strict{T}}) where {T} = T
-
-#####
 ##### `Skip`
 #####
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -433,14 +433,14 @@ See also: [`Extension`](@ref), [`extserialize`](@ref)
 extdeserialize(x::Extension) = (x.type, deserialize(IOBuffer(x.data)))
 
 #####
-##### `Exact`
+##### `Strict`
 #####
 
-struct Exact{T} end
+struct Strict{T} end
 
-msgpack_type(::Type{Exact{T}}) where {T} = StructType()
+msgpack_type(::Type{Strict{T}}) where {T} = StructType()
 
-unwrap_exact(::Type{Exact{T}}) where {T} = T
+unwrap_exact(::Type{Strict{T}}) where {T} = T
 
 #####
 ##### `Skip`

--- a/src/types.jl
+++ b/src/types.jl
@@ -19,8 +19,7 @@ The subtypes of `AbstractMsgPackType` are:
 - [`MapType`](@ref)
 - [`ExtensionType`](@ref)
 - [`AnyType`](@ref)
-- [`ImmutableStructType`](@ref)
-- [`MutableStructType`](@ref)
+- [`StructType`](@ref)
 """
 abstract type AbstractMsgPackType end
 
@@ -213,6 +212,8 @@ This type is similar to [`ImmutableStructType`](@ref), but imposes fewer
 constraints at the cost of (de)serialization performance.
 """
 struct MutableStructType <: AbstractMsgPackType end
+
+struct StructType <: AbstractMsgPackType end
 
 #####
 ##### `msgpack_type`, `to_msgpack`, `from_msgpack` defaults
@@ -430,6 +431,16 @@ that function's docstring for more details.
 See also: [`Extension`](@ref), [`extserialize`](@ref)
 """
 extdeserialize(x::Extension) = (x.type, deserialize(IOBuffer(x.data)))
+
+#####
+##### `Exact`
+#####
+
+struct Exact{T} end
+
+msgpack_type(::Type{Exact{T}}) where {T} = StructType()
+
+unwrap_exact(::Type{Exact{T}}) where {T} = T
 
 #####
 ##### `Skip`

--- a/src/unpack.jl
+++ b/src/unpack.jl
@@ -1,11 +1,11 @@
-unpack(x) = unpack(x, Any)
+unpack(x; strict::Tuple=()) = unpack(x, Any; strict=strict)
 
 """
     unpack(bytes, T::Type = Any)
 
 Return `unpack(IOBuffer(bytes), T)`.
 """
-unpack(bytes, ::Type{T}) where {T} = unpack(IOBuffer(bytes), T)
+unpack(bytes, ::Type{T}; strict::Tuple=()) where {T} = unpack(IOBuffer(bytes), T; strict=strict)
 
 """
     unpack(msgpack_byte_stream::IO, T::Type = Any)
@@ -22,30 +22,30 @@ default Julia representations, see [`AbstractMsgPackType`](@ref).
 
 See also: [`pack`](@ref)
 """
-unpack(io::IO, ::Type{T}) where {T} = unpack_type(io, read(io, UInt8), msgpack_type(T), T)
+unpack(io::IO, ::Type{T}; strict::Tuple=()) where {T} = unpack_type(io, read(io, UInt8), msgpack_type(T), T; strict=strict)
 
 #####
 ##### `AnyType`
 #####
 
-function unpack_type(io, byte, t::AnyType, U::Union)
+function unpack_type(io, byte, t::AnyType, U::Union; strict)
     A, B = U.a, U.b # Unions are sorted, so `Nothing`/`Missing` would be first
     if A === Nothing || A === Missing
         byte === magic_byte(NilFormat) && return from_msgpack(A, nothing)
-        return unpack_type(io, byte, msgpack_type(B), B)
+        return unpack_type(io, byte, msgpack_type(B), B; strict=strict)
     end
     return _unpack_any(io, byte, U)
 end
 
-@inline unpack_type(io, byte, ::AnyType, T::Type) = _unpack_any(io, byte, T)
+@inline unpack_type(io, byte, ::AnyType, T::Type; strict) = _unpack_any(io, byte, T; strict=strict)
 
-function _unpack_any(io, byte, ::Type{T}) where {T}
+function _unpack_any(io, byte, ::Type{T}; strict) where {T}
     if byte <= magic_byte_max(IntFixPositiveFormat)
         return unpack_format(io, IntFixPositiveFormat(byte), T)
     elseif byte <= magic_byte_max(MapFixFormat)
-        return unpack_format(io, MapFixFormat(byte), T)
+        return unpack_format(io, MapFixFormat(byte), T; strict=strict)
     elseif byte <= magic_byte_max(ArrayFixFormat)
-        return unpack_format(io, ArrayFixFormat(byte), T)
+        return unpack_format(io, ArrayFixFormat(byte), T; strict=strict)
     elseif byte <= magic_byte_max(StrFixFormat)
         return unpack_format(io, StrFixFormat(byte), T)
     elseif byte === magic_byte(UInt8Format)
@@ -81,13 +81,13 @@ function _unpack_any(io, byte, ::Type{T}) where {T}
     elseif byte === magic_byte(NilFormat)
         return unpack_format(io, NilFormat(), T)
     elseif byte === magic_byte(Array16Format)
-        return unpack_format(io, Array16Format(), T)
+        return unpack_format(io, Array16Format(), T; strict=strict)
     elseif byte === magic_byte(Array32Format)
-        return unpack_format(io, Array32Format(), T)
+        return unpack_format(io, Array32Format(), T; strict=strict)
     elseif byte === magic_byte(Map16Format)
-        return unpack_format(io, Map16Format(), T)
+        return unpack_format(io, Map16Format(), T; strict=strict)
     elseif byte === magic_byte(Map32Format)
-        return unpack_format(io, Map32Format(), T)
+        return unpack_format(io, Map32Format(), T; strict=strict)
     elseif byte === magic_byte(Ext8Format)
         return unpack_format(io, Ext8Format(), T)
     elseif byte === magic_byte(Ext16Format)
@@ -124,28 +124,26 @@ struct FieldNotFound end
 
 construct(::Type{T}, args...) where {T} = T(args...)
 
-function unpack_type(io, byte, ::StructType, ::Type{S}) where {S}
-    if S <: Strict
-        T = unwrap_exact(S)
+function unpack_type(io, byte, ::StructType, ::Type{T}; strict) where {T}
+    if any(T <: S for S in strict)
         byte > magic_byte_max(MapFixFormat) && read(io, UInt8)
         N = fieldcount(T)
         constructor = (args...) -> construct(T, args...)
         Base.@nexprs 32 i -> begin
             F_i = fieldtype(T, i)
-            unpack_type(io, read(io, UInt8), StringType(), Skip{Symbol})
-            x_i = unpack_type(io, read(io, UInt8), msgpack_type(F_i), F_i)
+            unpack_type(io, read(io, UInt8), StringType(), Skip{Symbol}; strict=strict)
+            x_i = unpack_type(io, read(io, UInt8), msgpack_type(F_i), F_i; strict=strict)
             N == i && return Base.@ncall i constructor x
         end
         others = Any[]
         for i in 33:N
             F_i = fieldtype(T, i)
-            push!(others, unpack_type(io, read(io, UInt8), msgpack_type(F_i), F_i))
+            push!(others, unpack_type(io, read(io, UInt8), msgpack_type(F_i), F_i; strict=strict))
         end
         return constructor(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13,
                            x14, x15, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25,
                            x26, x27, x28, x29, x30, x31, x32, others...)
     else
-        T = S
         if byte <= magic_byte_max(MapFixFormat)
             pair_count = xor(byte, magic_byte_min(MapFixFormat))
         elseif byte === magic_byte(Map16Format)
@@ -161,12 +159,12 @@ function unpack_type(io, byte, ::StructType, ::Type{S}) where {S}
             key = unpack(io, Symbol) # TODO validation check?
             Base.@nif(32,
                       i -> i <= N && fieldname(T, i) === key,
-                      i -> setindex!(fields, unpack(io, fieldtype(T, i)), i),
+                      i -> setindex!(fields, unpack(io, fieldtype(T, i); strict=strict), i),
                       i -> begin
                           is_field_still_unread = true
                           for j in 33:N
                               fieldname(T, j) === key || continue
-                              setindex!(fields, unpack(io, fieldtype(T, j)), j)
+                              setindex!(fields, unpack(io, fieldtype(T, j); strict=strict), j)
                               is_field_still_unread = false
                               break
                           end
@@ -177,42 +175,41 @@ function unpack_type(io, byte, ::StructType, ::Type{S}) where {S}
     end
 end
 
-function unpack_type(io, byte, ::StructType, ::Type{Skip{S}}) where {S}
-    if S <: Strict
-        T = unwrap_exact(S)
+function unpack_type(io, byte, ::StructType, ::Type{Skip{T}}; strict) where {T}
+    if any(T <: S for S in strict)
         N = fieldcount(T)
         byte > magic_byte_max(MapFixFormat) && read(io, UInt8)
         Base.@nexprs 32 i -> begin
             F_i = fieldtype(T, i)
-            unpack_type(io, read(io, UInt8), StringType(), Skip{Symbol})
-            unpack_type(io, read(io, UInt8), msgpack_type(F_i), Skip{F_i})
+            unpack_type(io, read(io, UInt8), StringType(), Skip{Symbol}; strict=strict)
+            unpack_type(io, read(io, UInt8), msgpack_type(F_i), Skip{F_i}; strict=strict)
             N == i && return Skip{T}()
         end
         for i in 33:N
             F_i = fieldtype(T, i)
-            unpack_type(io, read(io, UInt8), msgpack_type(F_i), Skip{F_i})
+            unpack_type(io, read(io, UInt8), msgpack_type(F_i), Skip{F_i}; strict=strict)
         end
     else
-        unpack_type(io, byte, MapType(), Skip{Dict{Symbol,Any}})
+        unpack_type(io, byte, MapType(), Skip{Dict{Symbol,Any}}; strict=strict)
     end
-    return Skip{S}()
+    return Skip{T}()
 end
 
 # NOTE: this is a deprecated code path
-function unpack_type(io, byte, ::ImmutableStructType, ::Type{T}) where {T}
-    return unpack_type(io, byte, StructType(), Strict{T})
+function unpack_type(io, byte, ::ImmutableStructType, ::Type{T}; strict) where {T}
+    return unpack_type(io, byte, StructType(), T; strict=(T, strict...))
 end
 
 # NOTE: this is a deprecated code path
-function unpack_type(io, byte, ::MutableStructType, ::Type{T}) where {T}
-    return unpack_type(io, byte, StructType(), T)
+function unpack_type(io, byte, ::MutableStructType, ::Type{T}; strict) where {T}
+    return unpack_type(io, byte, StructType(), T; strict=strict)
 end
 
 #####
 ##### `IntegerType`
 #####
 
-function unpack_type(io, byte, t::IntegerType, ::Type{T}) where {T}
+function unpack_type(io, byte, t::IntegerType, ::Type{T}; strict) where {T}
     if byte <= magic_byte_max(IntFixPositiveFormat)
         return unpack_format(io, IntFixPositiveFormat(byte), T)
     elseif byte === magic_byte(UInt8Format)
@@ -267,12 +264,12 @@ unpack_format(io, ::Int64Format, ::Type{T}) where {T<:Skip} = (skip(io, 8); T())
 ##### `NilType`
 #####
 
-function unpack_type(io, byte, ::NilType, ::Type{T}) where {T}
+function unpack_type(io, byte, ::NilType, ::Type{T}; strict) where {T}
     byte === magic_byte(NilFormat) && return unpack_format(io, NilFormat(), T)
     invalid_unpack(io, f, T)
 end
 
-unpack_type(io, byte, ::NilType, ::Type{T}) where {T<:Skip} = T()
+unpack_type(io, byte, ::NilType, ::Type{T}; strict) where {T<:Skip} = T()
 
 unpack_format(io, ::NilFormat, ::Type{T}) where {T} = from_msgpack(T, nothing)
 
@@ -280,13 +277,13 @@ unpack_format(io, ::NilFormat, ::Type{T}) where {T} = from_msgpack(T, nothing)
 ##### `BooleanType`
 #####
 
-function unpack_type(io, byte, t::BooleanType, ::Type{T}) where {T}
+function unpack_type(io, byte, t::BooleanType, ::Type{T}; strict) where {T}
     byte === magic_byte(TrueFormat) && return unpack_format(io, TrueFormat(), T)
     byte === magic_byte(FalseFormat) && return unpack_format(io, FalseFormat(), T)
     invalid_unpack(io, byte, t, T)
 end
 
-unpack_type(io, byte, ::BooleanType, ::Type{T}) where {T<:Skip} = T()
+unpack_type(io, byte, ::BooleanType, ::Type{T}; strict) where {T<:Skip} = T()
 
 unpack_format(io, ::TrueFormat, ::Type{T}) where {T} = from_msgpack(T, true)
 
@@ -296,7 +293,7 @@ unpack_format(io, ::FalseFormat, ::Type{T}) where {T} = from_msgpack(T, false)
 ##### `FloatType`
 #####
 
-function unpack_type(io, byte, t::FloatType, ::Type{T}) where {T}
+function unpack_type(io, byte, t::FloatType, ::Type{T}; strict) where {T}
     if byte === magic_byte(Float32Format)
         return unpack_format(io, Float32Format(), T)
     elseif byte === magic_byte(Float64Format)
@@ -315,7 +312,7 @@ unpack_format(io, ::Float64Format, ::Type{T}) where {T<:Skip} = (skip(io, 8); T(
 ##### `StringType`
 #####
 
-function unpack_type(io, byte, t::StringType, ::Type{T}) where {T}
+function unpack_type(io, byte, t::StringType, ::Type{T}; strict) where {T}
     if byte <= magic_byte_max(StrFixFormat)
         return unpack_format(io, StrFixFormat(byte), T)
     elseif byte === magic_byte(Str8Format)
@@ -355,7 +352,7 @@ _unpack_string(io::Base.GenericIOBuffer, n, ::Type{T}) where {T<:Skip} = (skip(i
 ##### `BinaryType`
 #####
 
-function unpack_type(io, byte, t::BinaryType, ::Type{T}) where {T}
+function unpack_type(io, byte, t::BinaryType, ::Type{T}; strict) where {T}
     if byte === magic_byte(Bin8Format)
         return unpack_format(io, Bin8Format(), T)
     elseif byte === magic_byte(Bin16Format)
@@ -378,108 +375,109 @@ _unpack_binary(io, n, ::Type{T}) where {T<:Skip} = (skip(io, n); T())
 ##### `ArrayType`
 #####
 
-function unpack_type(io, byte, t::ArrayType, ::Type{T}) where {T}
+function unpack_type(io, byte, t::ArrayType, ::Type{T}; strict) where {T}
     if byte <= magic_byte_max(ArrayFixFormat)
-        return unpack_format(io, ArrayFixFormat(byte), T)
+        return unpack_format(io, ArrayFixFormat(byte), T; strict=strict)
     elseif byte === magic_byte(Array16Format)
-        return unpack_format(io, Array16Format(), T)
+        return unpack_format(io, Array16Format(), T; strict=strict)
     elseif byte === magic_byte(Array32Format)
-        return unpack_format(io, Array32Format(), T)
+        return unpack_format(io, Array32Format(), T; strict=strict)
     else
         invalid_unpack(io, byte, t, T)
     end
 end
 
-unpack_format(io, ::Array16Format, ::Type{T}) where {T} = _unpack_array(io, ntoh(read(io, UInt16)), T)
-unpack_format(io, ::Array32Format, ::Type{T}) where {T} = _unpack_array(io, ntoh(read(io, UInt32)), T)
-unpack_format(io, f::ArrayFixFormat, ::Type{T}) where {T} = _unpack_array(io, xor(f.byte, magic_byte_min(ArrayFixFormat)), T)
+unpack_format(io, ::Array16Format, ::Type{T}; strict) where {T} = _unpack_array(io, ntoh(read(io, UInt16)), T; strict=strict)
+unpack_format(io, ::Array32Format, ::Type{T}; strict) where {T} = _unpack_array(io, ntoh(read(io, UInt32)), T; strict=strict)
+unpack_format(io, f::ArrayFixFormat, ::Type{T}; strict) where {T} = _unpack_array(io, xor(f.byte, magic_byte_min(ArrayFixFormat)), T; strict=strict)
 
 _eltype(T) = eltype(T)
 
-function _unpack_array(io, n, ::Type{T}) where {T}
+function _unpack_array(io, n, ::Type{T}; strict) where {T}
     E = _eltype(T)
     e = msgpack_type(E)
     result = Vector{E}(undef, n)
     for i in 1:n
-        result[i] = unpack_type(io, read(io, UInt8), e, E)
+        result[i] = unpack_type(io, read(io, UInt8), e, E; strict=strict)
     end
     return from_msgpack(T, result)
 end
 
-function _unpack_array(io, n, ::Type{Skip{T}}) where {T}
+function _unpack_array(io, n, ::Type{Skip{T}}; strict) where {T}
     E = _eltype(T)
     e = msgpack_type(E)
     for _ in 1:n
-        unpack_type(io, read(io, UInt8), e, Skip{E})
+        unpack_type(io, read(io, UInt8), e, Skip{E}; strict=strict)
     end
     return Skip{T}()
 end
 
-function _unpack_array(io::Base.GenericIOBuffer, n, ::Type{T}) where {T<:ArrayView}
+function _unpack_array(io::Base.GenericIOBuffer, n, ::Type{T}; strict) where {T<:ArrayView}
     E = _eltype(T)
     e = msgpack_type(E)
     start = position(io)
     positions = Vector{UInt64}(undef, n)
     for i in 1:length(positions)
         positions[i] = (position(io) - start) + 1
-        unpack_type(io, read(io, UInt8), e, Skip{E})
+        unpack_type(io, read(io, UInt8), e, Skip{E}; strict=strict)
     end
     bytes = view(io.data, (start + 1):position(io))
-    return ArrayView{E}(bytes, positions)
+    return ArrayView{E}(bytes, positions, strict)
 end
 
 #####
 ##### `MapType`
 #####
 
-function unpack_type(io, byte, t::MapType, ::Type{T}) where {T}
+function unpack_type(io, byte, t::MapType, ::Type{T}; strict) where {T}
     if byte <= magic_byte_max(MapFixFormat)
-        return unpack_format(io, MapFixFormat(byte), T)
+        return unpack_format(io, MapFixFormat(byte), T; strict=strict)
     elseif byte === magic_byte(Map16Format)
-        return unpack_format(io, Map16Format(), T)
+        return unpack_format(io, Map16Format(), T; strict=strict)
     elseif byte === magic_byte(Map32Format)
-        return unpack_format(io, Map32Format(), T)
+        return unpack_format(io, Map32Format(), T; strict=strict)
     else
         invalid_unpack(io, byte, t, T)
     end
 end
 
-unpack_format(io, ::Map16Format, ::Type{T}) where {T} = _unpack_map(io, ntoh(read(io, UInt16)), T)
-unpack_format(io, ::Map32Format, ::Type{T}) where {T} = _unpack_map(io, ntoh(read(io, UInt32)), T)
-unpack_format(io, f::MapFixFormat, ::Type{T}) where {T} = _unpack_map(io, xor(f.byte, magic_byte_min(MapFixFormat)), T)
+unpack_format(io, ::Map16Format, ::Type{T}; strict) where {T} = _unpack_map(io, ntoh(read(io, UInt16)), T; strict=strict)
+unpack_format(io, ::Map32Format, ::Type{T}; strict) where {T} = _unpack_map(io, ntoh(read(io, UInt32)), T; strict=strict)
+unpack_format(io, f::MapFixFormat, ::Type{T}; strict) where {T} = _unpack_map(io, xor(f.byte, magic_byte_min(MapFixFormat)), T; strict=strict)
 
 _keytype(T) = Any
 _keytype(::Type{T}) where {K,V,T<:AbstractDict{K,V}} = keytype(T)
+
 _valtype(T) = Any
 _valtype(::Type{T}) where {K,V,T<:AbstractDict{K,V}} = valtype(T)
 
-function _unpack_map(io, n, ::Type{T}) where {T}
+function _unpack_map(io, n, ::Type{T}; strict) where {T}
     K = _keytype(T)
     k = msgpack_type(K)
     V = _valtype(T)
     v = msgpack_type(V)
     dict = Dict{K,V}()
     for _ in 1:n
-        key = unpack_type(io, read(io, UInt8), k, K)
-        val = unpack_type(io, read(io, UInt8), v, V)
+        key = unpack_type(io, read(io, UInt8), k, K; strict=strict)
+        val = unpack_type(io, read(io, UInt8), v, V; strict=strict)
         dict[key] = val
     end
     return from_msgpack(T, dict)
 end
 
-function _unpack_map(io, n, ::Type{Skip{T}}) where {T}
+function _unpack_map(io, n, ::Type{Skip{T}}; strict) where {T}
     K = _keytype(T)
     k = msgpack_type(K)
     V = _valtype(T)
     v = msgpack_type(V)
     for i in 1:n
-        unpack_type(io, read(io, UInt8), k, Skip{K})
-        unpack_type(io, read(io, UInt8), v, Skip{V})
+        unpack_type(io, read(io, UInt8), k, Skip{K}; strict=strict)
+        unpack_type(io, read(io, UInt8), v, Skip{V}; strict=strict)
     end
     return Skip{T}()
 end
 
-function _unpack_map(io::Base.GenericIOBuffer, n, ::Type{T}) where {T<:MapView}
+function _unpack_map(io::Base.GenericIOBuffer, n, ::Type{T}; strict) where {T<:MapView}
     K = _keytype(T)
     k = msgpack_type(K)
     V = _valtype(T)
@@ -487,20 +485,20 @@ function _unpack_map(io::Base.GenericIOBuffer, n, ::Type{T}) where {T<:MapView}
     start = position(io)
     positions = Dict{K,UnitRange{UInt64}}()
     for _ in 1:n
-        key = unpack_type(io, read(io, UInt8), k, K)
+        key = unpack_type(io, read(io, UInt8), k, K; strict=strict)
         value_start = (position(io) - start) + 1
-        unpack_type(io, read(io, UInt8), v, Skip{V})
+        unpack_type(io, read(io, UInt8), v, Skip{V}; strict=strict)
         positions[key] = value_start:(position(io) - start)
     end
     bytes = view(io.data, (start + 1):position(io))
-    return MapView{K,V}(bytes, positions)
+    return MapView{K,V}(bytes, positions, strict)
 end
 
 #####
 ##### `ExtensionType`
 #####
 
-function unpack_type(io, byte, t::ExtensionType, ::Type{T}) where {T}
+function unpack_type(io, byte, t::ExtensionType, ::Type{T}; strict) where {T}
     byte === magic_byte(ExtFix1Format) && return unpack_format(io, ExtFix1Format(), T)
     byte === magic_byte(ExtFix2Format) && return unpack_format(io, ExtFix2Format(), T)
     byte === magic_byte(ExtFix4Format) && return unpack_format(io, ExtFix4Format(), T)

--- a/src/unpack.jl
+++ b/src/unpack.jl
@@ -124,7 +124,7 @@ struct FieldNotFound end
 
 construct(::Type{T}, args...) where {T} = T(args...)
 
-function unpack_type(io, byte, ::StructType, ::Type{T}; strict) where {T}
+function unpack_type(io, byte, t::StructType, ::Type{T}; strict) where {T}
     if any(T <: S for S in strict)
         byte > magic_byte_max(MapFixFormat) && read(io, UInt8)
         N = fieldcount(T)

--- a/src/unpack.jl
+++ b/src/unpack.jl
@@ -125,7 +125,7 @@ struct FieldNotFound end
 construct(::Type{T}, args...) where {T} = T(args...)
 
 function unpack_type(io, byte, ::StructType, ::Type{S}) where {S}
-    if S <: Exact
+    if S <: Strict
         T = unwrap_exact(S)
         byte > magic_byte_max(MapFixFormat) && read(io, UInt8)
         N = fieldcount(T)
@@ -178,7 +178,7 @@ function unpack_type(io, byte, ::StructType, ::Type{S}) where {S}
 end
 
 function unpack_type(io, byte, ::StructType, ::Type{Skip{S}}) where {S}
-    if S <: Exact
+    if S <: Strict
         T = unwrap_exact(S)
         N = fieldcount(T)
         byte > magic_byte_max(MapFixFormat) && read(io, UInt8)
@@ -200,7 +200,7 @@ end
 
 # NOTE: this is a deprecated code path
 function unpack_type(io, byte, ::ImmutableStructType, ::Type{T}) where {T}
-    return unpack_type(io, byte, StructType(), Exact{T})
+    return unpack_type(io, byte, StructType(), Strict{T})
 end
 
 # NOTE: this is a deprecated code path

--- a/src/unpack.jl
+++ b/src/unpack.jl
@@ -43,9 +43,9 @@ function _unpack_any(io, byte, ::Type{T}; strict) where {T}
     if byte <= magic_byte_max(IntFixPositiveFormat)
         return unpack_format(io, IntFixPositiveFormat(byte), T)
     elseif byte <= magic_byte_max(MapFixFormat)
-        return unpack_format(io, MapFixFormat(byte), T; strict=strict)
+        return unpack_format(io, MapFixFormat(byte), T, strict)
     elseif byte <= magic_byte_max(ArrayFixFormat)
-        return unpack_format(io, ArrayFixFormat(byte), T; strict=strict)
+        return unpack_format(io, ArrayFixFormat(byte), T, strict)
     elseif byte <= magic_byte_max(StrFixFormat)
         return unpack_format(io, StrFixFormat(byte), T)
     elseif byte === magic_byte(UInt8Format)
@@ -81,13 +81,13 @@ function _unpack_any(io, byte, ::Type{T}; strict) where {T}
     elseif byte === magic_byte(NilFormat)
         return unpack_format(io, NilFormat(), T)
     elseif byte === magic_byte(Array16Format)
-        return unpack_format(io, Array16Format(), T; strict=strict)
+        return unpack_format(io, Array16Format(), T, strict)
     elseif byte === magic_byte(Array32Format)
-        return unpack_format(io, Array32Format(), T; strict=strict)
+        return unpack_format(io, Array32Format(), T, strict)
     elseif byte === magic_byte(Map16Format)
-        return unpack_format(io, Map16Format(), T; strict=strict)
+        return unpack_format(io, Map16Format(), T, strict)
     elseif byte === magic_byte(Map32Format)
-        return unpack_format(io, Map32Format(), T; strict=strict)
+        return unpack_format(io, Map32Format(), T, strict)
     elseif byte === magic_byte(Ext8Format)
         return unpack_format(io, Ext8Format(), T)
     elseif byte === magic_byte(Ext16Format)
@@ -377,23 +377,23 @@ _unpack_binary(io, n, ::Type{T}) where {T<:Skip} = (skip(io, n); T())
 
 function unpack_type(io, byte, t::ArrayType, ::Type{T}; strict) where {T}
     if byte <= magic_byte_max(ArrayFixFormat)
-        return unpack_format(io, ArrayFixFormat(byte), T; strict=strict)
+        return unpack_format(io, ArrayFixFormat(byte), T, strict)
     elseif byte === magic_byte(Array16Format)
-        return unpack_format(io, Array16Format(), T; strict=strict)
+        return unpack_format(io, Array16Format(), T, strict)
     elseif byte === magic_byte(Array32Format)
-        return unpack_format(io, Array32Format(), T; strict=strict)
+        return unpack_format(io, Array32Format(), T, strict)
     else
         invalid_unpack(io, byte, t, T)
     end
 end
 
-unpack_format(io, ::Array16Format, ::Type{T}; strict) where {T} = _unpack_array(io, ntoh(read(io, UInt16)), T; strict=strict)
-unpack_format(io, ::Array32Format, ::Type{T}; strict) where {T} = _unpack_array(io, ntoh(read(io, UInt32)), T; strict=strict)
-unpack_format(io, f::ArrayFixFormat, ::Type{T}; strict) where {T} = _unpack_array(io, xor(f.byte, magic_byte_min(ArrayFixFormat)), T; strict=strict)
+unpack_format(io, ::Array16Format, ::Type{T}, strict) where {T} = _unpack_array(io, ntoh(read(io, UInt16)), T, strict)
+unpack_format(io, ::Array32Format, ::Type{T}, strict) where {T} = _unpack_array(io, ntoh(read(io, UInt32)), T, strict)
+unpack_format(io, f::ArrayFixFormat, ::Type{T}, strict) where {T} = _unpack_array(io, xor(f.byte, magic_byte_min(ArrayFixFormat)), T, strict)
 
 _eltype(T) = eltype(T)
 
-function _unpack_array(io, n, ::Type{T}; strict) where {T}
+function _unpack_array(io, n, ::Type{T}, strict) where {T}
     E = _eltype(T)
     e = msgpack_type(E)
     result = Vector{E}(undef, n)
@@ -403,7 +403,7 @@ function _unpack_array(io, n, ::Type{T}; strict) where {T}
     return from_msgpack(T, result)
 end
 
-function _unpack_array(io, n, ::Type{Skip{T}}; strict) where {T}
+function _unpack_array(io, n, ::Type{Skip{T}}, strict) where {T}
     E = _eltype(T)
     e = msgpack_type(E)
     for _ in 1:n
@@ -412,7 +412,7 @@ function _unpack_array(io, n, ::Type{Skip{T}}; strict) where {T}
     return Skip{T}()
 end
 
-function _unpack_array(io::Base.GenericIOBuffer, n, ::Type{T}; strict) where {T<:ArrayView}
+function _unpack_array(io::Base.GenericIOBuffer, n, ::Type{T}, strict) where {T<:ArrayView}
     E = _eltype(T)
     e = msgpack_type(E)
     start = position(io)
@@ -431,19 +431,19 @@ end
 
 function unpack_type(io, byte, t::MapType, ::Type{T}; strict) where {T}
     if byte <= magic_byte_max(MapFixFormat)
-        return unpack_format(io, MapFixFormat(byte), T; strict=strict)
+        return unpack_format(io, MapFixFormat(byte), T, strict)
     elseif byte === magic_byte(Map16Format)
-        return unpack_format(io, Map16Format(), T; strict=strict)
+        return unpack_format(io, Map16Format(), T, strict)
     elseif byte === magic_byte(Map32Format)
-        return unpack_format(io, Map32Format(), T; strict=strict)
+        return unpack_format(io, Map32Format(), T, strict)
     else
         invalid_unpack(io, byte, t, T)
     end
 end
 
-unpack_format(io, ::Map16Format, ::Type{T}; strict) where {T} = _unpack_map(io, ntoh(read(io, UInt16)), T; strict=strict)
-unpack_format(io, ::Map32Format, ::Type{T}; strict) where {T} = _unpack_map(io, ntoh(read(io, UInt32)), T; strict=strict)
-unpack_format(io, f::MapFixFormat, ::Type{T}; strict) where {T} = _unpack_map(io, xor(f.byte, magic_byte_min(MapFixFormat)), T; strict=strict)
+unpack_format(io, ::Map16Format, ::Type{T}, strict) where {T} = _unpack_map(io, ntoh(read(io, UInt16)), T, strict)
+unpack_format(io, ::Map32Format, ::Type{T}, strict) where {T} = _unpack_map(io, ntoh(read(io, UInt32)), T, strict)
+unpack_format(io, f::MapFixFormat, ::Type{T}, strict) where {T} = _unpack_map(io, xor(f.byte, magic_byte_min(MapFixFormat)), T, strict)
 
 _keytype(T) = Any
 _keytype(::Type{T}) where {K,V,T<:AbstractDict{K,V}} = keytype(T)
@@ -451,7 +451,7 @@ _keytype(::Type{T}) where {K,V,T<:AbstractDict{K,V}} = keytype(T)
 _valtype(T) = Any
 _valtype(::Type{T}) where {K,V,T<:AbstractDict{K,V}} = valtype(T)
 
-function _unpack_map(io, n, ::Type{T}; strict) where {T}
+function _unpack_map(io, n, ::Type{T}, strict) where {T}
     K = _keytype(T)
     k = msgpack_type(K)
     V = _valtype(T)
@@ -465,7 +465,7 @@ function _unpack_map(io, n, ::Type{T}; strict) where {T}
     return from_msgpack(T, dict)
 end
 
-function _unpack_map(io, n, ::Type{Skip{T}}; strict) where {T}
+function _unpack_map(io, n, ::Type{Skip{T}}, strict) where {T}
     K = _keytype(T)
     k = msgpack_type(K)
     V = _valtype(T)
@@ -477,7 +477,7 @@ function _unpack_map(io, n, ::Type{Skip{T}}; strict) where {T}
     return Skip{T}()
 end
 
-function _unpack_map(io::Base.GenericIOBuffer, n, ::Type{T}; strict) where {T<:MapView}
+function _unpack_map(io::Base.GenericIOBuffer, n, ::Type{T}, strict) where {T<:MapView}
     K = _keytype(T)
     k = msgpack_type(K)
     V = _valtype(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,10 +2,16 @@ using Test, MsgPack, Serialization
 
 function can_round_trip(value, T,
                         expected_typed_output = value,
-                        expected_any_output = value,
-                        check_strict = false)
+                        expected_any_output = value)
     bytes = pack(value)
-    return isequal(unpack(bytes, T; strict=(T,)), expected_typed_output) &&
+    if T <: AbstractArray
+        S = eltype(T)
+    elseif T <: AbstractDict
+        S = valtype(T)
+    else
+        S = T
+    end
+    return isequal(unpack(bytes, T; strict=(S,)), expected_typed_output) &&
            isequal(unpack(bytes, T), expected_typed_output) &&
            isequal(unpack(bytes), expected_any_output)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,16 +171,16 @@ foo = Foo{Int,String}(nothing, String["abc", join(rand(Char,typemax(UInt16)))],
                       Bar(rand(Int), rand(Int)))
 foo_dict = Dict("x" => foo.x, "y" => foo.y, "z" => Dict("a" => foo.z.a, "b" => foo.z.b))
 @test can_round_trip(foo, typeof(foo), foo, foo_dict)
-@test can_round_trip(foo, MsgPack.Exact{typeof(foo)}, foo, foo_dict)
+@test can_round_trip(foo, MsgPack.Strict{typeof(foo)}, foo, foo_dict)
 
 foo = Foo{Float64,Char}(rand(), rand('a':'z', 100), Bar(rand(), rand()))
 foo_dict = Dict("x" => foo.x, "y" => map(string, foo.y), "z" => Dict("a" => foo.z.a, "b" => foo.z.b))
 @test can_round_trip(foo, typeof(foo), foo, foo_dict)
-@test can_round_trip(foo, MsgPack.Exact{typeof(foo)}, foo, foo_dict)
+@test can_round_trip(foo, MsgPack.Strict{typeof(foo)}, foo, foo_dict)
 
 arr = [foo, foo]
 @test can_round_trip(arr, MsgPack.ArrayView{typeof(foo)}, arr, [foo_dict, foo_dict])
-@test can_round_trip(arr, MsgPack.ArrayView{MsgPack.Exact{typeof(foo)}}, arr, [foo_dict, foo_dict])
+@test can_round_trip(arr, MsgPack.ArrayView{MsgPack.Strict{typeof(foo)}}, arr, [foo_dict, foo_dict])
 
 mutable struct MBar{T}
     a::T


### PR DESCRIPTION
initial attempt at addressing #35. still needs: 

- [x] performance checks
- [x] deprecation warnings for the old `ImmutableStructType`/`MutableStructType`
- [x] documentation updates

I realized that there are more assumptions at play here than just ordering; I couldn't think of a succinct term that precisely captures them all, though, so I just use the vague `Exact{T}` - open to better names if folks have ideas! EDIT: @ararslan used the word "strict" here which I kind of like