### PR TITLE
Include type info in errors from pack()

### DIFF
--- a/src/pack.jl
+++ b/src/pack.jl
@@ -354,5 +354,5 @@ end
 #####
 
 @noinline function invalid_pack(io, t, x)
-    error("cannot serialize Julia value $(x) as MsgPack type $(t) to $(io)")
+    error("cannot serialize Julia value $(x) with type $(typeof(x)) as MsgPack type $(t) to $(io)")
 end


### PR DESCRIPTION
Minor fix, this makes debugging unsupported types a bit easier.