### PR TITLE
fixed unpack of Tuple

### DIFF
--- a/src/unpack.jl
+++ b/src/unpack.jl
@@ -422,6 +422,20 @@ function _unpack_array(io, n, ::Type{Skip{T}}, strict) where {T}
     return Skip{T}()
 end
 
+function _unpack_array(io, n, ::Type{T}, strict) where {N, T<:Tuple{Vararg{Any, N}}}
+    return T(tuple((
+        unpack_type(io, read(io, UInt8), msgpack_type(fieldtype(T, i)), fieldtype(T, i); strict=strict)
+        for i in 1:N
+    )...))
+end
+
+function _unpack_array(io, n, ::Type{Skip{T}}, strict) where {T<:Tuple}
+    for i in 1:N
+        unpack_type(io, read(io, UInt8), msgpack_type(fieldtype(T, i)), fieldtype(T, i); strict=strict)
+    end
+    return Skip{T}()
+end
+
 function _unpack_array(io::Base.GenericIOBuffer, n, ::Type{T}, strict) where {T<:ArrayView}
     E = _eltype(T)
     e = msgpack_type(E)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,6 +110,10 @@ end
 tup = (arr...,)
 @test can_round_trip(tup, Tuple, tup, arr)
 
+@test can_round_trip(tup, typeof(tup), tup, arr)
+
+@test can_round_trip((true, tup), typeof((true, tup)), (true, tup), [true, arr])
+
 set = Set(arr)
 @test can_round_trip(set, Set, set, collect(set))
 


### PR DESCRIPTION
Without the fix, the added unit test throws an error:

  Test threw exception                                                                                                                                                                         
  Expression: can_round_trip((true, tup), typeof((true, tup)), (true, tup), [true, arr])                                                                                                       
  MethodError: Cannot `convert` an object of type Vector{Any} to an object of type Tuple{Int64, Int64, UInt8, UInt16, UInt32, UInt64, Int8, Int8, Int16, Int16, Int32, Int32, Int64, Int64, Nothing, Float32, Float64, Bool, Bool, String, Vector{Any}}

I'm not sure why the existing unit tests don't catch this.