### PR TITLE
`strict` `UndefKeywordError` bugfix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MsgPack"
 uuid = "99f44e22-a591-53d1-9472-aa23ef4bd671"
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/src/unpack.jl
+++ b/src/unpack.jl
@@ -41,7 +41,7 @@ function unpack_type(io, byte, t::AnyType, U::Union; strict)
         byte === magic_byte(NilFormat) && return from_msgpack(A, nothing)
         return unpack_type(io, byte, msgpack_type(B), B; strict=strict)
     end
-    return _unpack_any(io, byte, U)
+    return _unpack_any(io, byte, U; strict=strict)
 end
 
 @inline unpack_type(io, byte, ::AnyType, T::Type; strict) = _unpack_any(io, byte, T; strict=strict)


### PR DESCRIPTION
Fixes 
```julia
ERROR: UndefKeywordError: keyword argument `strict` not assigned
```