### PR TITLE
ArrayStructType

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -20,6 +20,7 @@ The subtypes of `AbstractMsgPackType` are:
 - [`ExtensionType`](@ref)
 - [`AnyType`](@ref)
 - [`StructType`](@ref)
+- [`ArrayStructType`](@ref)
 """
 abstract type AbstractMsgPackType end
 
@@ -191,6 +192,9 @@ struct StructType <: AbstractMsgPackType end
 
 @deprecate MutableStructType() StructType() false
 @deprecate ImmutableStructType() StructType() false
+
+# FIXME docs
+struct ArrayStructType <: AbstractMsgPackType end
 
 #####
 ##### `msgpack_type`, `to_msgpack`, `from_msgpack` defaults


### PR DESCRIPTION
This adds packing type ArrayStructType, which is similar to StructType but packs using arrays rather than string maps.  This gives more efficient storage, as well as providing interoperability with other systems that store their msgpack data in this way.

Let me know if you are interested in this.  If so, I'll clean it up and add documentation and tests.